### PR TITLE
Added support for micro-library

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'ember-ma-square',
 
   treeForApp: function() {
-    return this.buildTree(this.root, ['component.js']);
+    return this.buildTree(this.root, ['component.js', 'library.js']);
   },
 
   treeForTemplates: function() {
@@ -35,6 +35,8 @@ module.exports = {
   mapFile: function(relativePath) {
     if (relativePath === 'component.js') {
       return path.join('components', this.name + '.js');
+    } else if (relativePath === 'library.js') {
+      return path.join('lib', this.name + '.js');
     } else if (relativePath === 'template.hbs') {
       return path.join('components', this.name + '.hbs');
     } else if (relativePath === 'style.css') {

--- a/library.js
+++ b/library.js
@@ -1,0 +1,7 @@
+function square(number) {
+  return number*number;
+}
+
+export {
+  square
+}


### PR DESCRIPTION
- [Asana task: Make the micro-addon concept work with libraries](https://app.asana.com/0/26202368814744/37277203843171)
# Description

This PR adds support for a library to the micro-addon concept. The idea is that we just create an addon with `package.json`, `library.js` and associated dependencies. With the proper `index.js`, the `library.js` file then gets moved to the proper location at runtime, so it's importable via

``` JavaScript
import myLibrary from `${app-name}/lib/${addon-name}`;
```
# Solution

It was simpler than I thought. 

There is no file overlap between a library and a component, so it was just a matter of mapping `library.js` to `lib/${addon-name}.js`.
