### PR TITLE
Support for helper in micro-addon concept

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Handlebars.makeBoundHelper(function() {
+  return 'A random ember-ma-square helper';
+});

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'ember-ma-square',
 
   treeForApp: function() {
-    return this.buildTree(this.root, ['component.js', 'library.js']);
+    return this.buildTree(this.root, ['component.js', 'library.js', 'helper.js']);
   },
 
   treeForTemplates: function() {
@@ -37,6 +37,8 @@ module.exports = {
       return path.join('components', this.name + '.js');
     } else if (relativePath === 'library.js') {
       return path.join('lib', this.name + '.js');
+    } else if (relativePath === 'helper.js') {
+      return path.join('helpers', this.name + '.js');
     } else if (relativePath === 'template.hbs') {
       return path.join('components', this.name + '.hbs');
     } else if (relativePath === 'style.css') {


### PR DESCRIPTION
- [Asana task: Make the micro-addon concept work with helpers](https://app.asana.com/0/26202368814744/37277203843173)
# Description

This PR adds support for helpers within the micro-addon concept. The idea is that the addon needs a `package.json` and a `helper.js`. At build time of the parent app, `helper.js` is renamed and moved to `app/helpers/${addon-name}.js` and is usable as a regular helper.
# Solution

As with other cases (component and library) the reality is that we need a specifically written `index.js` to enable this, as well as several other support files (which technically aren't art of the solution).

In the case of this proof of concept addon, we have all 3 examples within a single addon. In a typical real-life scenario, each micro-addon would typically provide either a component, a library or a helper, not all 3 or even two at once. 

Since this is a non-typical scenario, the problem we have is that in a handlebars template, the helper overwrites the component, meaning adding `{{ember-ma-square}}` to any app template would render the helper, not the component. The solution for this specific case is to render the component via the component helper - `{{component "ember-ma-square"}}`.
